### PR TITLE
Remove OPI build line from Makefile

### DIFF
--- a/OxInstIPSApp/Makefile
+++ b/OxInstIPSApp/Makefile
@@ -4,7 +4,6 @@ DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *opi*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard protocol))
 include $(TOP)/configure/RULES_DIRS
 


### PR DESCRIPTION
Remove OPI line from Makefile that causes build to fail