### PR TITLE
Fix: alarms.cpp and .h RHEL6 build complained about static and extern…

### DIFF
--- a/OxInstIPSApp/src/alarms.cpp
+++ b/OxInstIPSApp/src/alarms.cpp
@@ -127,7 +127,7 @@ bool strcmp_nocase(const string& a, const string& b)
                       });
 }
 
-static long handle_system_alarm_status(aSubRecord *prec)
+long handle_system_alarm_status(aSubRecord *prec)
     {
     vector<string> token_list;
     vector<string> BOARD_ARRAY;

--- a/OxInstIPSApp/src/alarms.h
+++ b/OxInstIPSApp/src/alarms.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-extern long handle_system_alarm_status(aSubRecord *prec);
+long handle_system_alarm_status(aSubRecord *prec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
… both declared. Attributes now removed.